### PR TITLE
Remove annotations from legend

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -24,6 +24,7 @@ class Annotations {
   private static defaultTrace = {
     type: 'bar',
     name: null,
+    showlegend: false,
     yaxis: `y${Annotations.LAYOUT_YAXIS}`,
     hoverinfo: 'x+text',
     x: [],


### PR DESCRIPTION
Just remove the ugly "trace 1" element from the legend when displaying annotations.