### PR TITLE
Fix grafana-sdk-mocks dependency (fixes #74)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "clean-webpack-plugin": "^1.0.1",
     "copy-webpack-plugin": "^4.5.1",
     "css-loader": "^2.1.0",
-    "grafana-sdk-mocks": "github:ryantxu/grafana-sdk-mocks",
+    "grafana-sdk-mocks": "github:grafana/grafana-sdk-mocks",
     "jest": "^24.1.0",
     "ng-annotate-webpack-plugin": "^0.3.0",
     "prettier": "^1.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4975,9 +4975,9 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-"grafana-sdk-mocks@github:ryantxu/grafana-sdk-mocks":
+"grafana-sdk-mocks@github:grafana/grafana-sdk-mocks":
   version "1.0.0"
-  resolved "https://codeload.github.com/ryantxu/grafana-sdk-mocks/tar.gz/0df804e3044c6f88713b508cfa2a555b883496e8"
+  resolved "https://codeload.github.com/grafana/grafana-sdk-mocks/tar.gz/8022ff1856048f8716d00b15b4423795b81f8369"
 
 gray-matter@^3.0.8:
   version "3.1.1"


### PR DESCRIPTION
Temporarily update `grafana-sdk-mocks` to fix build; long term solution would be to use `@types/grafana` I believe