### PR TITLE
Call renderingCompleted

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -517,7 +517,9 @@ class PlotlyPanelCtrl extends MetricsPanelCtrl {
       });
       this.initialized = true;
     } else if (this.initialized) {
-      Plotly.redraw(this.graphDiv);
+      Plotly.redraw(this.graphDiv).then(() => {
+        this.renderingCompleted();
+      });
     } else {
       console.log('Not initialized yet!');
     }


### PR DESCRIPTION
This should fix issue #55.

I've tested the fix with the grafana-image-renderer plugin and the rendering of a dashboard: the renderer was waiting for window.panelsRendered>=panelCount, so each panel is supposed to call renderingCompleted when it has finished.